### PR TITLE
CI reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
           path: coverage.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Yorkshire Vitality Observatory Data Pipeline
 
 [![CI](https://github.com/yhoda-project/YHODA/actions/workflows/ci.yml/badge.svg)](https://github.com/yhoda-project/YHODA/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/yhoda-project/YHODA/branch/main/graph/badge.svg)](https://codecov.io/gh/yhoda-project/YHODA)
+[![codecov](https://codecov.io/gh/yhoda-project/YHODA/graph/badge.svg?token=L2VWHIOGTL)](https://codecov.io/gh/yhoda-project/YHODA)
 [![Docs](https://img.shields.io/badge/docs-passing-brightgreen)](https://yhoda-project.github.io/YHODA)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Prefect](https://img.shields.io/badge/prefect-v3-blue)](https://www.prefect.io/)


### PR DESCRIPTION
This pull request updates the Codecov integration to improve CI reliability and badge accuracy. The main changes are upgrading to the latest Codecov GitHub Action, adding the required authentication token, and updating the Codecov badge in the `README.md`.

**CI/CD and Codecov Integration:**

* Upgraded the Codecov GitHub Action in `.github/workflows/ci.yml` from version 4 to version 5 and added the `CODECOV_TOKEN` for authentication to ensure uploads work correctly.

**Documentation:**

* Updated the Codecov badge in `README.md` to use a token-authenticated URL, ensuring the badge displays coverage status reliably.