### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by ensuring that the Codecov upload step always runs, regardless of previous step outcomes.

* CI workflow reliability:
  * Modified the `jobs` section in `.github/workflows/ci.yml` to add `if: always()` to the Codecov upload step, ensuring code coverage is uploaded even if earlier steps fail.