### PR TITLE
Add correlations table and update compute_correlations step

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -1,6 +1,6 @@
 # Database
 
-The pipeline stores all its data in a PostgreSQL database called `yhoda_dev` (staging) or `yhoda_prod` (production). There are six tables.
+The pipeline stores all its data in a PostgreSQL database called `yhoda_dev` (staging) or `yhoda_prod` (production). There are seven tables.
 
 See [Query the database](../how-to/query-the-database.md) for instructions on connecting and running queries.
 
@@ -62,6 +62,20 @@ Business counts by industry and turnover band at MSOA level. This powers the Ind
 ### `industry_business_kpi`
 
 Pre-calculated business count change statistics - 3-year and 8-year percentage changes - at Yorkshire-wide, LAD, and MSOA level. These figures are calculated when the data is loaded and stored ready for the dashboard to display without further calculation.
+
+---
+
+### `correlations`
+
+Pre-computed pairwise Spearman rank correlations between all Observatory indicators. One row exists for every ordered pair of indicators, including self-pairs (rho = 1) and symmetric duplicates.
+
+Each row stores the Spearman rho, p-value, a flag for statistical significance (p < 0.05), and a plain-English interpretation message ready for display in the dashboard.
+
+This table must be refreshed after any change to the `indicator` table by running:
+
+```bash
+uv run python -m yhovi_pipeline.utils.compute_correlations
+```
 
 ---
 

--- a/docs/how-to/load-static-data.md
+++ b/docs/how-to/load-static-data.md
@@ -112,6 +112,18 @@ This runs `load_all()`, which iterates over every entry in `CSV_FILES` and `LONG
 
 ---
 
+## Refresh the correlations table
+
+After running `load_all()`, refresh the pre-computed correlations so the dashboard correlation matrix reflects the updated data:
+
+```bash
+uv run python -m yhovi_pipeline.utils.compute_correlations
+```
+
+This recomputes all pairwise Spearman correlations across every indicator in the database and upserts the results. With 50 indicators this produces 2,500 pairs and takes under a minute.
+
+---
+
 ## Verifying the load
 
 Connect to the database (see [Query the database](query-the-database.md)) and run:

--- a/docs/reference/entity-relationship-diagram.md
+++ b/docs/reference/entity-relationship-diagram.md
@@ -1,6 +1,6 @@
 # Entity Relationship Diagram
 
-This diagram shows the six tables in the YHODA database and how they relate to each other.
+This diagram shows the seven tables in the YHODA database and how they relate to each other.
 
 The `geo_lookup` table is the geography dimension - it links the other tables via geography codes. The `dataset_metadata` table links to `indicator` via the `dataset_code` field, allowing any indicator row to be traced back to the pipeline run that loaded it.
 
@@ -109,9 +109,24 @@ erDiagram
     timestamp updated_at
   }
 
+  correlations {
+    int id PK
+    varchar indicator_1_id
+    varchar indicator_2_id
+    varchar indicator_1_name
+    varchar indicator_2_name
+    float spearman_rho
+    float p_value
+    boolean is_significant
+    text message
+    timestamp computed_at
+  }
+
   geo_lookup ||..o{ indicator : "geography_code / lad_code"
   geo_lookup ||..o{ jobs_lsoa : "lsoa_code"
   geo_lookup ||..o{ industry_business : "msoa_code"
   geo_lookup ||..o{ industry_business_kpi : "lad_code"
   dataset_metadata ||..o{ indicator : "dataset_code"
+  indicator ||..o{ correlations : "indicator_id / indicator_1_id"
+  indicator ||..o{ correlations : "indicator_id / indicator_2_id"
 ```


### PR DESCRIPTION
This pull request updates the documentation to reflect the addition of a new `correlations` table to the YHODA database. The changes include an updated database overview, details about the new table and its purpose, instructions for refreshing the correlations data, and an updated entity relationship diagram.

**Database schema documentation updates:**

* Updated references to indicate there are now seven tables in the database, not six, in both `database.md` and `entity-relationship-diagram.md`. [[1]](diffhunk://#diff-137dfbda9867a3708e0a2a838b5d6fc7d00ee87650e81701839b6d24e40c5cf3L3-R3) [[2]](diffhunk://#diff-dc746baf4bf1a04a4f6cd455c08a234c5b6f79c829c44f58c52a5bcc519115a0L3-R3)

**New `correlations` table:**

* Added a detailed description of the new `correlations` table, which stores pre-computed pairwise Spearman rank correlations between all Observatory indicators, including its fields and refresh instructions, to `database.md`.

**How-to and maintenance instructions:**

* Added a new section to `load-static-data.md` explaining how and when to refresh the `correlations` table after loading data, including the command to run and expected performance.

**Entity relationship diagram:**

* Updated the entity relationship diagram and its description to include the new `correlations` table and its links to the `indicator` table. [[1]](diffhunk://#diff-dc746baf4bf1a04a4f6cd455c08a234c5b6f79c829c44f58c52a5bcc519115a0R112-R131) [[2]](diffhunk://#diff-dc746baf4bf1a04a4f6cd455c08a234c5b6f79c829c44f58c52a5bcc519115a0L3-R3)…compute_correlations step